### PR TITLE
Add Busted tests

### DIFF
--- a/doc/fast_agent.txt
+++ b/doc/fast_agent.txt
@@ -144,6 +144,18 @@
 "     ─────────────────────────────────────────────────────────────────────
 "     Finds the last assistant message in the “current” conversation 
 "     and appends it to `<filepath>`.  
+
+==============================================================================
+6. Tests                                                      *fast_agent-tests*
+------------------------------------------------------------------------------
+To run the plugin's automated tests you need the |busted| framework
+available in your $PATH.  From the repository root directory simply run:
+
+    busted
+
+This will execute all spec files under |tests/| and report the results.
+
+==============================================================================
 "
 "============================================================================== 
 " For more details or to contribute, see the GitHub repo.  

--- a/tests/test_conversation.lua
+++ b/tests/test_conversation.lua
@@ -1,0 +1,22 @@
+-- Adjust package path so Lua can find fast_agent.lua
+package.path = table.concat({
+  'lua/?.lua',
+  package.path
+}, ';')
+
+local fast = require('fast_agent')
+
+describe('conversation management', function()
+  it('creates a new conversation and lists it', function()
+    local id = fast.create_new_conversation()
+    local list = fast.list_conversations()
+    local found = false
+    for _, c in ipairs(list) do
+      if c.id == id then
+        found = true
+        break
+      end
+    end
+    assert.is_true(found)
+  end)
+end)


### PR DESCRIPTION
## Summary
- add a small test suite using Busted
- document how to run the tests in `fast_agent.txt`

## Testing
- `busted` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684669b33298832e832e344c3e677e7e